### PR TITLE
Fix for safari desktop

### DIFF
--- a/theme/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/theme/lms/static/sass/partials/lms/theme/_extras.scss
@@ -45,6 +45,7 @@ header.global-header {
     position: fixed;
     top: 0;
     z-index: 200; // necessary to keep the header on top of other elements
+    overflow: visible;  // fix for Safari
   }
   //background-color: #4c61bf;
   box-shadow: none;


### PR DESCRIPTION
On Safari for Macos the user menu is clipped due to a Safari bug. If you set both overflow:hidden and position:fixed on a parent element, a child element with position: fixed will incorrectly be clipped by the parent element. The fix for this is to remove overflow:visible on large screens, where it isn't required anyway.